### PR TITLE
Return the emitter object from each emitter function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,20 @@
 module.exports = function() {
-  var subscribers = []
-  return {
+  var subscribers = [], self
+  return self = {
     on: function (eventName, cb) {
-      subscribers.push({
+      return subscribers.push({
         eventName: eventName,
         cb: cb
-      })
+      }) && self
     },
     trigger: function (eventName, data) {
-      subscribers
+      return subscribers
         .filter(function (subscriber) {
           return subscriber.eventName === eventName
         })
         .forEach(function (subscriber) {
           subscriber.cb(data)
-        })
+        }) && self
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function() {
         })
         .forEach(function (subscriber) {
           subscriber.cb(data)
-        }) && self
+        }) || self
     }
   }
 }

--- a/test/spec.js
+++ b/test/spec.js
@@ -21,7 +21,7 @@ describe('emitter20', function () {
   
   it('should return itself', function (done) {
     var emitter = new Emitter()
-    emitter.on('later', done).trigger('later')
+    emitter.trigger('test').on('later', done).trigger('later')
   })
 
 })

--- a/test/spec.js
+++ b/test/spec.js
@@ -18,5 +18,10 @@ describe('emitter20', function () {
     })
     emitter.trigger('welcome', 'bob')
   })
+  
+  it('should return itself', function (done) {
+    var emitter = new Emitter()
+    emitter.on('later', done).trigger('later')
+  })
 
 })


### PR DESCRIPTION
This is a simple change that allows chaining `.on` and `.trigger` calls. Here's an example of it being used, using the Magic: the Gathering developer sdk:

```ts
const sets: Set[] = [];
Sets.all({}).on("data", (set) => {
	sets.push(set);
}).on("end", async () => {
	const newestSet = sets.reduce((newest, set) => new Date(set.releaseDate) > new Date(newest.releaseDate) ? set : newest);
	const cards = await Cards.where({
		types: "Creature|Instant|Sorcery|Enchantment|Artifact|Planeswalker",
		setName: newestSet.name,
		page: 0,
		pageSize: 50,
		random: true,
	});
	for (const card of cards) {
		this.append(new Card(card));
	}
});
```

Without these changes I would be required to make a variable for the emitter; this is a simple change with simple benefits, but benefits regardless in my opinion. Feel free to reject if you dislike the code or the idea tho. (The only reason I used the less clear && operator for returning the emitter was to keep it 20 lines)